### PR TITLE
Switch production compose file to use :prod tag

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,19 +5,14 @@ version: '2.4'
 services:
   fishblog-app:
     container_name: fishblog-app
-    # production: track "prod" tag on ghcr.io
-    # image: ghcr.io/wetfish/blog:prod
     # for development, build the image
+    image: ghcr.io/wetfish/blog:dev
     build: .
-
     # restart unless we stopped it manually
     restart: unless-stopped
-
     # our config file
     volumes:
       - "./config.js:/app/server/config.js:ro"
-
     # normally behind centeral traefik defined in production-manifests/services/traefik
-    # localhost for dev, feel free to change listen address
     ports:
       - "127.0.0.1:2304:2304"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,9 +8,8 @@ services:
     # production: track "prod" tag on ghcr.io
     # image: ghcr.io/wetfish/blog:prod
     # for development, build the image
-    # TODO: once ghcr.io autobuilds in place, change this
     build: .
-    
+
     # restart unless we stopped it manually
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,22 +7,12 @@ services:
     container_name: fishblog-app
     # production: track "prod" tag on ghcr.io
     image: ghcr.io/wetfish/blog:prod
-
     # restart unless we stopped it manually
     restart: unless-stopped
-
     # our config file
     volumes:
       - "./config.js:/app/server/config.js:ro"
-
-    # uncomment to expose port directly
     # normally behind centeral traefik defined in production-manifests/services/traefik
-    # ports:
-    #   - "2304:2304"
-
-    # join the traefik backend network
-    # comment out this and the networks: stanza below
-    # if you uncomment the port exposure above
     networks:
       traefik-backend: {}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,8 @@ services:
   fishblog-app:
     container_name: fishblog-app
     # production: track "prod" tag on ghcr.io
-    # image: ghcr.io/wetfish/blog:prod
-    # for development, build the image
-    # TODO: once ghcr.io autobuilds in place, change this
-    build: .
-    
+    image: ghcr.io/wetfish/blog:prod
+
     # restart unless we stopped it manually
     restart: unless-stopped
 


### PR DESCRIPTION
Quick one to switch the production compose file to use `ghcr.io/wetfish/blog:prod` instead of building the container locally.

Also removed an unnecessary/unwanted comment and some whitespace trimming.
